### PR TITLE
Polyphonic erase

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Record → Play → Overdub → Play → Overdub → … → Stop → Play → �
 
 ### Multi-Track Recording
 
-Looper's stereo inputs and outputs are [polyphonic](https://vcvrack.com/manual/Polyphony), meaning you can record up to 32 tracks in total (left and right, 16 channels each). Connect a polyphonic cable to an input and press the big toggle button to start recording. Each channel of polyphony on the input will record on a separate internal track and play back on the corresponding output channel. Use VCV's [Merge](https://library.vcvrack.com/Fundamental/Merge) and [Split](https://library.vcvrack.com/Fundamental/Split) modules to manage polyphony.
+Looper's stereo inputs and outputs are [polyphonic](https://vcvrack.com/manual/Polyphony), meaning you can record up to 32 tracks in total (left and right, 16 channels each). Connect a polyphonic cable to an input and press the big toggle button to start recording. Each channel of polyphony on the input will record on a separate internal track and play back on the corresponding output channel. Additionally, tracks can be erased individually by passing polyphonic input into the Erase CV input. Putting a monophonic cable into the Erase CV input will erase all tracks. Use VCV's [Merge](https://library.vcvrack.com/Fundamental/Merge) and [Split](https://library.vcvrack.com/Fundamental/Split) modules to manage polyphony. 
 
 ### Known Issues & Limitations
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "slug": "LilacLoop",
   "name": "Lilac Loop",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "license": "GPL-3.0-or-later",
   "brand": "Lilac",
   "author": "Gavin Rough",

--- a/src/Looper.cpp
+++ b/src/Looper.cpp
@@ -227,7 +227,7 @@ if(erasing) {
         if (loop[track].empty()) {
           out = monitorLevel * in;
         } else {
-          if(in > .01 && loopEmpty[track]) {
+          if(std::abs(in) > .01 && loopEmpty[track]) {
             loopEmpty[track] = false;
           }
           out = monitorLevel * in + loopLevel * outputGate * loop[track][pos[track]];


### PR DESCRIPTION
This is per-track erase for the erase cv input. Passing a gate on an individual channel will erase the corresponding recorded track. Passing a monophonic input will erase all tracks. Line 230 in Looper.cpp is a little bit hacky but i think it's reasonable because the incoming voltage was never exactly equal to 0.